### PR TITLE
Check against lowercase username

### DIFF
--- a/profilewesnothd/event/main_listener.php
+++ b/profilewesnothd/event/main_listener.php
@@ -70,7 +70,7 @@ class main_listener implements EventSubscriberInterface
 			$username = $event['member']['username'];
 
 			$sql = 'SELECT user_lastvisit FROM ' . $this->db->sql_escape($wesnothd_tblname) . ' ' .
-			       "WHERE username = '" . $this->db->sql_escape(utf8_clean_string($username)) . "'";
+			       "WHERE LOWER(username) = '" . $this->db->sql_escape(utf8_clean_string($username)) . "'";
 			$result = $this->db->sql_query($sql);
 			$last_mp_join = (int)$this->db->sql_fetchfield('user_lastvisit');
 			$this->db->sql_freeresult($result);


### PR DESCRIPTION
The entries in the wesnothd table can have mixed case.

Not sure if utf8_clean_string is really needed/appropriate here but it probably makes no difference for the allowed user names.